### PR TITLE
Switch Search Service dependency to ^3 tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-search-service": "dev-feature/silverstripe-5",
+        "silverstripe/silverstripe-search-service": "^3",
         "elastic/enterprise-search": "^8.6",
         "guzzlehttp/guzzle": "^7"
     },


### PR DESCRIPTION
`3.0.0-beta1` has now been tagged for Silverstripe Search Service.